### PR TITLE
Add OpenAI radiology report feature

### DIFF
--- a/apps/papra-server/package.json
+++ b/apps/papra-server/package.json
@@ -58,6 +58,7 @@
     "nanoid": "^5.1.5",
     "node-cron": "^3.0.3",
     "nodemailer": "^7.0.3",
+    "openai": "^5.7.0",
     "p-limit": "^6.2.0",
     "p-queue": "^8.1.0",
     "picomatch": "^4.0.2",

--- a/apps/papra-server/src/modules/app/server.routes.ts
+++ b/apps/papra-server/src/modules/app/server.routes.ts
@@ -13,6 +13,7 @@ import { registerUsersRoutes } from '../users/users.routes';
 import { registerWebhooksRoutes } from '../webhooks/webhook.routes';
 import { registerAuthRoutes } from './auth/auth.routes';
 import { registerHealthCheckRoutes } from './health-check/health-check.routes';
+import { registerRadiologyReportsRoutes } from '../openai/radiology-reports.routes';
 
 export function registerRoutes(context: RouteDefinitionContext) {
   registerAuthRoutes(context);
@@ -26,6 +27,7 @@ export function registerRoutes(context: RouteDefinitionContext) {
   registerTagsRoutes(context);
   registerTaggingRulesRoutes(context);
   registerApiKeysRoutes(context);
+  registerRadiologyReportsRoutes(context);
   registerWebhooksRoutes(context);
   registerInvitationsRoutes(context);
   registerDocumentActivityRoutes(context);

--- a/apps/papra-server/src/modules/config/config.ts
+++ b/apps/papra-server/src/modules/config/config.ts
@@ -18,6 +18,7 @@ import { createLogger } from '../shared/logger/logger';
 import { subscriptionsConfig } from '../subscriptions/subscriptions.config';
 import { tasksConfig } from '../tasks/tasks.config';
 import { trackingConfig } from '../tracking/tracking.config';
+import { openAiConfig } from '../openai/openai.config';
 import { booleanishSchema, trustedOriginsSchema } from './config.schemas';
 
 export const configDefinition = {
@@ -89,6 +90,7 @@ export const configDefinition = {
   organizationPlans: organizationPlansConfig,
   subscriptions: subscriptionsConfig,
   tracking: trackingConfig,
+  openai: openAiConfig,
 } as const satisfies ConfigDefinition;
 
 const logger = createLogger({ namespace: 'config' });

--- a/apps/papra-server/src/modules/openai/openai.config.ts
+++ b/apps/papra-server/src/modules/openai/openai.config.ts
@@ -1,0 +1,16 @@
+import type { ConfigDefinition } from 'figue';
+import { z } from 'zod';
+
+export const openAiConfig = {
+  apiKey: {
+    doc: 'API key for OpenAI',
+    schema: z.string().default(''),
+    env: 'OPENAI_API_KEY',
+  },
+  model: {
+    doc: 'OpenAI model used for radiology reports',
+    schema: z.string(),
+    default: 'gpt-4o',
+    env: 'OPENAI_MODEL',
+  },
+} as const satisfies ConfigDefinition;

--- a/apps/papra-server/src/modules/openai/radiology-reports.routes.ts
+++ b/apps/papra-server/src/modules/openai/radiology-reports.routes.ts
@@ -1,0 +1,24 @@
+import type { RouteDefinitionContext } from '../app/server.types';
+import { z } from 'zod';
+import { requireAuthentication } from '../app/auth/auth.middleware';
+import { validateJsonBody } from '../shared/validation/validation';
+import { createRadiologyReportsService } from './radiology-reports.services';
+
+export function registerRadiologyReportsRoutes(context: RouteDefinitionContext) {
+  setupGenerateReportRoute(context);
+}
+
+function setupGenerateReportRoute({ app, config }: RouteDefinitionContext) {
+  const service = createRadiologyReportsService({ config });
+
+  app.post(
+    '/api/radiology/report',
+    requireAuthentication(),
+    validateJsonBody(z.object({ exam: z.string(), findings: z.string() })),
+    async (ctx) => {
+      const { exam, findings } = ctx.req.valid('json');
+      const { report } = await service.generateReport({ exam, findings });
+      return ctx.json({ report });
+    },
+  );
+}

--- a/apps/papra-server/src/modules/openai/radiology-reports.services.test.ts
+++ b/apps/papra-server/src/modules/openai/radiology-reports.services.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test, vi } from 'vitest';
+import { createRadiologyReportsService } from './radiology-reports.services';
+
+vi.mock('openai', () => {
+  return {
+    default: class {
+      chat = { completions: { create: vi.fn().mockResolvedValue({ choices: [{ message: { content: 'mock report' } }] }) } };
+    },
+  };
+});
+
+describe('radiology reports services', () => {
+  test('generateReport returns the ai report', async () => {
+    const service = createRadiologyReportsService({ config: { openai: { apiKey: 'key', model: 'gpt-4o' } } as any });
+    const { report } = await service.generateReport({ exam: 'CT chest', findings: 'no abnormalities' });
+    expect(report).toBe('mock report');
+  });
+});

--- a/apps/papra-server/src/modules/openai/radiology-reports.services.ts
+++ b/apps/papra-server/src/modules/openai/radiology-reports.services.ts
@@ -1,0 +1,34 @@
+import type { Config } from '../config/config.types';
+import { createError } from '../shared/errors/errors';
+import OpenAI from 'openai';
+
+export function createRadiologyReportsService({ config }: { config: Config }) {
+  const apiKey = config.openai.apiKey;
+  if (!apiKey) {
+    throw createError({
+      message: 'OpenAI API key not configured',
+      code: 'openai.missing_api_key',
+      statusCode: 500,
+      isInternal: true,
+    });
+  }
+
+  const openai = new OpenAI({ apiKey });
+  const model = config.openai.model;
+
+  async function generateReport({ exam, findings }: { exam: string; findings: string }) {
+    const completion = await openai.chat.completions.create({
+      model,
+      messages: [
+        { role: 'system', content: 'You are a radiology assistant AI generating concise radiology reports.' },
+        { role: 'user', content: `Exam: ${exam}\nFindings: ${findings}` },
+      ],
+    });
+
+    const report = completion.choices[0]?.message?.content ?? '';
+
+    return { report };
+  }
+
+  return { generateReport };
+}

--- a/packages/api-sdk/src/api-client.ts
+++ b/packages/api-sdk/src/api-client.ts
@@ -11,6 +11,7 @@ export function createClient({ apiKey, apiBaseUrl = PAPRA_API_URL }: { apiKey: s
   const methods = injectArguments(
     {
       uploadDocument,
+      generateRadiologyReport,
     },
     { apiClient },
   );
@@ -32,5 +33,13 @@ async function uploadDocument({
   return await apiClient<{ document: PapraDocument }>(`/api/organizations/${organizationId}/documents`, {
     method: 'POST',
     body: formData,
+  });
+}
+
+async function generateRadiologyReport({ exam, findings, apiClient }: { exam: string; findings: string; apiClient: ApiClient }) {
+  return await apiClient<{ report: string }>('/api/radiology/report', {
+    method: 'POST',
+    body: JSON.stringify({ exam, findings }),
+    headers: { 'Content-Type': 'application/json' },
   });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,6 +322,9 @@ importers:
       nodemailer:
         specifier: ^7.0.3
         version: 7.0.3
+      openai:
+        specifier: ^5.7.0
+        version: 5.7.0(ws@8.18.2)(zod@3.25.28)
       p-limit:
         specifier: ^6.2.0
         version: 6.2.0
@@ -6202,6 +6205,18 @@ packages:
 
   oniguruma-to-es@4.3.3:
     resolution: {integrity: sha512-rPiZhzC3wXwE59YQMRDodUwwT9FZ9nNBwQQfsd1wfdtlKEyCdRV0avrTcSZ5xlIvGRVPd/cx6ZN45ECmS39xvg==}
+
+  openai@5.7.0:
+    resolution: {integrity: sha512-zXWawZl6J/P5Wz57/nKzVT3kJQZvogfuyuNVCdEp4/XU2UNrjL7SsuNpWAyLZbo6HVymwmnfno9toVzBhelygA==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   opencollective-postinstall@2.0.3:
     resolution: {integrity: sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==}
@@ -15102,6 +15117,11 @@ snapshots:
       oniguruma-parser: 0.12.1
       regex: 6.0.1
       regex-recursion: 6.0.2
+
+  openai@5.7.0(ws@8.18.2)(zod@3.25.28):
+    optionalDependencies:
+      ws: 8.18.2
+      zod: 3.25.28
 
   opencollective-postinstall@2.0.3: {}
 


### PR DESCRIPTION
## Summary
- add OpenAI dependency
- expose OpenAI config options
- create radiology report service and route
- register the new API route
- expose client helper for generating radiology reports
- basic service test
- accept exam and findings fields for report generation

## Testing
- `pnpm --filter @papra/app-server test` *(fails: Failed to resolve entry for package `@papra/webhooks`)*

------
https://chatgpt.com/codex/tasks/task_e_685a385ff6c8832992694a5088640663

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an API endpoint to generate radiology reports using AI, requiring exam and findings input.
  - Added configuration options for OpenAI integration, including API key and model selection.
  - Exposed a new client method to generate radiology reports via the API.

- **Tests**
  - Added automated tests to verify AI-generated radiology report functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->